### PR TITLE
Install criterion from rpm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,16 +136,7 @@ RUN cd /tmp \
     && python3 setup.py install \
     && cd \
     && rm -rf /tmp/pyte \
-    && cd /tmp && git clone --branch v2.3.2 https://github.com/Snaipe/Criterion \
-    && cd Criterion \
-    && mkdir build \
-    && cd build \
-    && cmake -DCMAKE_INSTALL_PREFIX=/usr .. \
-    && cmake --build . \
-    && make install \
-    && ldconfig \
-    && cd \
-    && rm -rf /tmp/Criterion \
+    && rpm -ivh https://github.com/samber/criterion-rpm-package/releases/download/2.3.2/libcriterion-devel-v2.3.2-0.x86_64.rpm \
     && cd /tmp && git clone https://github.com/runkit7/runkit7.git \
     && cd runkit7 \
     && git checkout 7ddbbb0d4784751a55eac0f4f425fbc2e1d249f6 \


### PR DESCRIPTION
Testing:

```
docker build -t test-criterion .
docker run --rm -it test-criterion /bin/bash

[root] $ git clone https://github.com/Snaipe/Criterion
[root] $ cd Criterion/samples
[root] $ gcc -o simple simple.c -lcriterion
[root] $ ./simple
```