### PR TITLE
feat: add clang-analyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y install dnf-plugins-core         \
         boost-static.x86_64                 \
         ca-certificates.noarch              \
         clang.x86_64                        \
+        clang-analyzer                      \
         cmake.x86_64                        \
         curl.x86_64                         \
         elfutils-libelf-devel.x86_64        \


### PR DESCRIPTION
Need for static analysis of C and C++ code (to find multiple source of errors and memory leaks).