### PR TITLE
feat: Remove the now useless Microsoft repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,7 @@ RUN dnf -y install dnf-plugins-core         \
     && dnf -y install vim                   \
     && dnf clean all -y
 
-RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
-        && wget -q -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/32/prod.repo \
-        && dnf -y install                   \
+RUN     dnf -y install                      \
         cargo                               \
         dotnet-sdk-3.1                      \
         ghc                                 \


### PR DESCRIPTION
Starting from Fedora 32, [adding the Microsoft repository is not needed](https://docs.microsoft.com/fr-fr/dotnet/core/install/linux-fedora#fedora-32-), as it is now [available in the default repository](https://rpmfind.net/linux/RPM/fedora/32/x86_64/d/dotnet-sdk-3.1-3.1.101-4.fc32.x86_64.html)