### PR TITLE
Add Vlang support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,3 +140,11 @@ RUN cd /tmp \
     && bash build_csfml.sh \
     && rm -rf /tmp/* \
     && chmod 1777 /tmp
+
+RUN mkdir -pv /opt/vlang \
+    && cd /opt/vlang \
+    && git clone https://github.com/vlang/v \
+    && cd v \
+    && git checkout 6ad5ecf \
+    && make \
+    && ln -sv /opt/vlang/v /usr/local/bin/v

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,8 +143,8 @@ RUN cd /tmp \
 
 RUN mkdir -pv /opt/vlang \
     && cd /opt/vlang \
-    && git clone https://github.com/vlang/v \
-    && cd v \
-    && git checkout 6ad5ecf \
-    && make \
-    && ln -sv /opt/vlang/v /usr/local/bin/v
+    && wget https://github.com/vlang/v/releases/download/0.1.29/v_linux.zip \
+    && unzip v_linux.zip \
+    && rm -v v_linux.zip \
+    && chmod +x ./v/v \
+    && ln -sv /opt/vlang/v/v /usr/local/bin/v


### PR DESCRIPTION
Vlang is a relatively new programming language that is a mix between golang and rust.
As both of those are currently included in the Epitest docker image I thought it would make a nice
addition for people wanting a new and powerful tool for Epitech projects.

More infos about the language [here](https://github.com/vlang/v)