### PR TITLE
feat: add gmock and gbenchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,8 @@ RUN     dnf -y --refresh install            \
         php-phar-io-version.noarch          \
         php-theseer-tokenizer.noarch        \
         rust.x86_64                         \
+        google-benchmark.x86_64             \
+        gmock                               \
         java-11-openjdk-11.0.9.11-9.fc32.x86_64       \
         java-11-openjdk-devel-11.0.9.11-9.fc32.x86_64 \
     && dnf clean all -y


### PR DESCRIPTION
This commits aims to these packages to the docker image:
• [Google mock](https://github.com/google/googletest/tree/master/googlemock)
• [Google benchmark](https://github.com/google/benchmark)

I think it would be a great addition to the docker
Often used by student by downloading and building it directly within their cmake files