### PR TITLE
Add workdir instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,3 +146,5 @@ RUN cd /tmp \
     && bash build_csfml.sh \
     && rm -rf /tmp/* \
     && chmod 1777 /tmp
+
+WORKDIR /usr/app


### PR DESCRIPTION
Adding a default workdir would avoid using `cd /whatever/location` when we do a docker run.
For example, this is how I start the epitest-docker when I need to do some manual tests.

```bash
docker run --rm -it -v /home/code/malloc:/usr/app epitechcontent/epitest-docker:latest /bin/bash
```
Currently, without a workdir instruction, I need to `cd /usr/app`. It's not a big deal but it is still annoying.
(The location `/usr/app` can be changed for anything more revelant if you want to)