### PR TITLE
Add UUID library support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ RUN     dnf -y --refresh install            \
         php-phar-io-version.noarch          \
         php-theseer-tokenizer.noarch        \
         rust.x86_64                         \
+        libuuid libuuid-devel               \
         java-11-openjdk-11.0.11.0.9-0.fc32.x86_64 \
         java-11-openjdk-devel-11.0.11.0.9-0.fc32.x86_64 \
     && dnf clean all -y


### PR DESCRIPTION
Hello,

I'm working on the MyTeams project, which needs to generate some uuid.
Currently, the Dockerfile is not installing `libuuid` nor `libuuid-devel` which leads to a compilation error `include/common.h:15:10: fatal error: uuid/uuid.h: No such file or directory`

As a workaround, I am installing `libuuid libuuid-devel` before running our Makefile but I think it is revelant to add this in the official public docker for other students.

Build has been tested and is working.
Thanks for reviewing this PR.