### PR TITLE
feat: add allegro5 library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,8 @@ RUN     dnf -y --refresh install            \
         java-17-openjdk                     \
         java-17-openjdk-devel               \
         bc                                  \
+        allegro5                            \
+        allegro5-devel.x86_64               \
     && dnf clean all -y
 
 RUN python3 -m pip install --upgrade pip \
@@ -128,7 +130,7 @@ RUN cd /tmp \
     && echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
     && ldconfig
 
-RUN cd /tmp \ 
+RUN cd /tmp \
    && curl -sSL https://get.haskellstack.org/ | sh
 
 ENV LANG=en_US.utf8 LANGUAGE=en_US:en LC_ALL=en_US.utf8 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig


### PR DESCRIPTION
The allegro5 library is allowed in the subject of the Arcade project. However, the image does not compile a program using it. This is a minor issue but a student is worried of having a build error on the delivery. 
I tested my changes with the hello world program from the [quickstart](https://github.com/liballeg/allegro5/wiki/Quickstart) of the library.
As I am writing this, I just saw that my editor did trimming by adding a newline at the end of the file and deleted a trailing space.