### PR TITLE
feat: update Dockerfile to migrate to Fedora 39 and QoL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,136 +1,146 @@
 FROM fedora:39
 LABEL maintainer="Thomas Dufour <thomas.dufour@epitech.eu>"
 
-RUN dnf -y upgrade                          \
-        && dnf -y install dnf-plugins-core  \
-        && dnf -y --refresh install         \
-        --setopt=tsflags=nodocs             \
-        --setopt=deltarpm=false             \
-        allegro5                            \
-        allegro5-devel.x86_64               \
-        SDL2                                \
-        SDL2-devel.x86_64                   \
-        SDL2-static.x86_64                  \
-        SDL2_image.x86_64                   \
-        SDL2_image-devel.x86_64             \
-        SDL2_ttf                            \
-        SDL2_ttf-devel.x86_64               \
-        SDL2_mixer                          \
-        SDL2_mixer-devel.x86_64             \
-        SDL2_gfx                            \
-        SDL2_gfx-devel.x86_64               \
-        libcaca.x86_64                      \
-        libcaca-devel.x86_64                \
-        SFML.x86_64                         \
-        SFML-devel.x86_64                   \
-        CSFML.x86_64                        \
-        CSFML-devel.x86_64                  \
-        autoconf                            \
-        automake                            \
-        boost                               \
-        boost-devel.x86_64                  \
-        boost-graph                         \
-        boost-math                          \
-        boost-static.x86_64                 \
-        ca-certificates.noarch              \
-        clang.x86_64                        \
-        clang-analyzer                      \
-        cmake.x86_64                        \
-        curl.x86_64                         \
-        elfutils-libelf-devel.x86_64        \
-        gcc-c++.x86_64                      \
-        gcc.x86_64                          \
-        gdb.x86_64                          \
-        git                                 \
-        glibc-devel.x86_64                  \
-        glibc-locale-source.x86_64          \
-        glibc.x86_64                        \
-        gmp-devel.x86_64                    \
-        ksh.x86_64                          \
-        langpacks-en                        \
-        libasan.x86_64                      \
-        libubsan.x86_64                     \
-        libtsan.x86_64                      \
-        libconfig                           \
-        libconfig-devel                     \
-        libX11-devel.x86_64                 \
-        libXext-devel.x86_64                \
-        libXrandr-devel.x86_64              \
-        libXinerama-devel.x86_64            \
-        libXcursor-devel.x86_64             \
-        libXi-devel.x86_64                  \
-        libjpeg-turbo-devel.x86_64          \
-        libtsan                             \
-        llvm.x86_64                         \
-        llvm-devel.x86_64                   \
-        ltrace.x86_64                       \
-        make.x86_64                         \
-        nasm.x86_64                         \
-        ncurses-devel.x86_64                \
-        ncurses-libs                        \
-        ncurses.x86_64                      \
-        net-tools.x86_64                    \
-        nc                                  \
-        openal-soft-devel.x86_64            \
-        openssl-devel                       \
-        patch                               \
-        procps-ng.x86_64                    \
-        python3.x86_64                      \
-        python3-devel.x86_64                \
-        rlwrap.x86_64                       \
-        ruby.x86_64                         \
-        strace.x86_64                       \
-        sudo.x86_64                         \
-        systemd-devel                       \
-        tar.x86_64                          \
-        tcsh.x86_64                         \
-        tmux.x86_64                         \
-        tree.x86_64                         \
-        unzip.x86_64                        \
-        diffutils                           \
-        valgrind.x86_64                     \
-        wget.x86_64                         \
-        which.x86_64                        \
-        xcb-util-image-devel.x86_64         \
-        xcb-util-image.x86_64               \
-        xz.x86_64                           \
-        zip.x86_64                          \
-        zsh.x86_64                          \
-        vim                                 \
-    && dnf clean all -y
+RUN dnf -y upgrade \
+    && dnf -y install dnf-plugins-core \
+    && dnf -y --refresh install \
+    --setopt=tsflags=nodocs \
+    --setopt=deltarpm=false \
+    CSFML \
+    CSFML-devel \
+    SDL2 \
+    SDL2-devel \
+    SDL2-static \
+    SDL2_gfx \
+    SDL2_gfx-devel \
+    SDL2_image \
+    SDL2_image-devel \
+    SDL2_mixer \
+    SDL2_mixer-devel \
+    SDL2_ttf \
+    SDL2_ttf-devel \
+    SFML \
+    SFML-devel \
+    allegro5 \
+    allegro5-devel \
+    autoconf \
+    automake \
+    boost \
+    boost-devel \
+    boost-graph \
+    boost-math \
+    boost-static \
+    ca-certificates \
+    clang \
+    clang-analyzer \
+    cmake \
+    curl \
+    diffutils \
+    elfutils-libelf-devel \
+    gcc \
+    gcc-c++ \
+    gdb \
+    git \
+    glibc \
+    glibc-devel \
+    glibc-locale-source \
+    gmp-devel \
+    ksh \
+    langpacks-en \
+    libX11-devel \
+    libXcursor-devel \
+    libXext-devel \
+    libXi-devel \
+    libXinerama-devel \
+    libXrandr-devel \
+    libasan \
+    libcaca \
+    libcaca-devel \
+    libconfig \
+    libconfig-devel \
+    libjpeg-turbo-devel \
+    libtsan \
+    libtsan \
+    libubsan \
+    llvm \
+    llvm-devel \
+    ltrace \
+    make \
+    nasm \
+    nc \
+    ncurses \
+    ncurses-devel \
+    ncurses-libs \
+    net-tools \
+    openal-soft-devel \
+    openssl-devel \
+    patch \
+    procps-ng \
+    python3 \
+    python3-devel \
+    rlwrap \
+    ruby \
+    strace \
+    sudo \
+    systemd-devel \
+    tar \
+    tcsh \
+    tmux \
+    tree \
+    unzip \
+    valgrind \
+    vim \
+    wget \
+    which \
+    xcb-util-image \
+    xcb-util-image-devel \
+    xz \
+    zip \
+    zsh \
+    && dnf clean all -y \
+    && rm -rf /var/cache/yum
 
 # Large layer was splitted because build timeout on push to github package
-RUN     dnf -y --refresh install            \
-        cargo                               \
-        rust                                \
-        ghc                                 \
-        golang                              \
-        nodejs                              \
-        php.x86_64                          \
-        php-devel.x86_64                    \
-        php-bcmath.x86_64                   \
-        php-cli.x86_64                      \
-        php-devel.x86_64                    \
-        php-gd.x86_64                       \
-        php-mbstring.x86_64                 \
-        php-mysqlnd.x86_64                  \
-        php-pdo.x86_64                      \
-        php-pear.noarch                     \
-        php-pdo.x86_64                      \
-        php-xml.x86_64                      \
-        php-gettext-gettext.noarch          \
-        php-phar-io-version.noarch          \
-        php-theseer-tokenizer.noarch        \
-        libuuid libuuid-devel               \
-        java-17-openjdk                     \
-        java-17-openjdk-devel               \
-        bc                                  \
-    && dnf clean all -y
+RUN dnf -y --refresh install \
+    --setopt=tsflags=nodocs \
+    --setopt=deltarpm=false \
+    bc \
+    gcovr \
+    ghc \
+    golang \
+    java-17-openjdk \
+    java-17-openjdk-devel \
+    libuuid libuuid-devel \
+    nodejs \
+    php \
+    php-bcmath \
+    php-cli \
+    php-devel \
+    php-devel \
+    php-gd \
+    php-gettext-gettext \
+    php-mbstring \
+    php-mysqlnd \
+    php-pdo \
+    php-pdo \
+    php-pear \
+    php-phar-io-version \
+    php-theseer-tokenizer \
+    php-xml \
+    python-numpy \
+    python-pycryptodomex \
+    python-pyte \
+    python-requests \
+    rustup \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
 
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install -Iv gcovr==6.0 pycryptodome==3.18.0 requests==2.31.0 pyte==0.8.1 numpy==1.25.2 \
     && localedef -i en_US -f UTF-8 en_US.UTF-8 \
-    && npm install -g bun
+    && rustup-init -y --default-toolchain stable
+
+RUN cd /tmp \
+    && curl -fsSL https://bun.sh/install | bash
 
 RUN cd /tmp \
     && curl -sSL "https://github.com/Snaipe/Criterion/releases/download/v2.4.2/criterion-2.4.2-linux-x86_64.tar.xz" -o /tmp/criterion.tar.xz \
@@ -139,7 +149,7 @@ RUN cd /tmp \
     && echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
     && ldconfig
 
-RUN cd /tmp \ 
+RUN cd /tmp \
    && curl -sSL https://get.haskellstack.org/ | sh
 
 ENV LANG=en_US.utf8 LANGUAGE=en_US:en LC_ALL=en_US.utf8 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:39
 LABEL maintainer="Thomas Dufour <thomas.dufour@epitech.eu>"
 
 RUN dnf -y upgrade                          \


### PR DESCRIPTION
Updating to Fedora 39 for benefiting from latest toolchains versions. Notably some new features for C++20 compliance.
And some other QoL fixes.

- Sorted packages in dnf install for readability
- Some style modifications
- Delete cache on every dnf install to reduce layer size
- Install python packages via dnf instead of pip to avoid conflicts with system packages
- Install rust via rustup, the official rust installer 
- Install bun via the official install script
- Remove target triplet which is not necessary

P.S.: Is it normal that an external contributor can run jobs on your jenkins ?