### PR TITLE
Slim down the image from 6.06GB to 4.94GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         zsh \
         curl \
         && apt-get clean -y \
-        && rm -rf /var/lib/apt/lists/*
+        && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /usr/share/doc/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && npm install -g bun \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ LABEL maintainer="Alexandre Vanhecke <alexandre1.vanhecke@epitech.eu>"
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
         && apt-get update -y \
-        && apt-get install -y software-properties-common apt-utils \
+        && apt-get install -y --no-install-recommends software-properties-common apt-utils \
         && add-apt-repository -y -s universe \
         && apt-get update                 \
         && apt-get upgrade -y             \
-        && apt-get install -y             \
+        && apt-get install -y --no-install-recommends \
         avr-libc \
         build-essential \
         ca-certificates-java \
@@ -117,6 +117,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         x264 \
         zip \
         zsh \
+        curl \
         && apt-get clean -y \
         && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         x264 \
         zip \
         zsh \
-        && apt-get clean -y
+        && apt-get clean -y \
+        && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && npm install -g bun \


### PR DESCRIPTION
There are 3 things that have been done in this PR:
- Removing apt's lists which is some cache left behind even after `apt-get clean`
- Not installing recommended packages, those can include documentation and other packages that are not useful in a container
- Removing some easy to remove documentation, because some packages have strong deps on their documentation for some reason

Each commit is documented as to why they are here.
As a bonus `apt-get clean` might not need to be called at all as per [this](https://github.com/moby/moby/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105) but I left it there to be more explicit.

Lastly the indentation is just not consistent throughout the dockerfile but I didn't change it to avoid messing with git blame.

Some data on the size of the image with each commit:
```
Before removing apt lists: 6.06GB
After removing apt lists: 5.97GB
After --no-install-recommends: 5.09GB
After doc remove: 4.94GB
```