### PR TITLE
feat: add qtbase5-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         jupyter-notebook \
         qt6-base-dev \
         qt6-base-dev-tools \
+        qtbase5-dev \
         rlwrap \
         ruby \
         rustc \


### PR DESCRIPTION
This pull request includes a minor change to the `Dockerfile`. The change adds `qtbase5-dev` to the list of packages being installed.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R120): Added `qtbase5-dev` to the list of packages being installed.

*Useful for Arcade Project