### PR TITLE
feat: add libgtest-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         ca-certificates-java \
         cabal-install \
         cargo \
+        libgtest-dev \
         clang \
         clang-tools \
         cmake \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to include an additional dependency required for building and testing C++ code.

Dependency updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R20): Added `libgtest-dev` to the list of installed packages, enabling support for Google Test, a popular C++ testing framework.